### PR TITLE
add linting and support users with '_' in their name

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,19 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+jobs:
+  lint:
+    name: lint & check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Ansible Playbook
+        uses: ansible/ansible-lint-action@main
+        with:
+          targets: "./"
+          args: "-q"
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v6.6.1
+    hooks:
+      - id: ansible-lint
+        files: \.(yaml|yml)$
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ait
 name: owncloud
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.3.1
+version: 0.3.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -16,7 +16,8 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-- Maximilian Frank <maximilian.frank@ait.ac.at>
+  - Benjamin Akhras <maximilian.frank@ait.ac.at>
+  - Maximilian Frank
 
 
 ### OPTIONAL but strongly recommended
@@ -25,7 +26,7 @@ description: Additional roles and modules for configuring ownCloud installations
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'
-license_file: 'LICENSE'
+license_file: 'GPLv3'
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
@@ -54,4 +55,3 @@ issues: https://github.com/ait-cs-IaaS/ansible-collection-owncloud/issues
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered
 build_ignore: []
-

--- a/plugins/modules/oc_user.py
+++ b/plugins/modules/oc_user.py
@@ -50,7 +50,7 @@ options:
     type: list
   password:
     description:
-      - The password to set when the user is created. (Use C(force_password) if you want to change the password of an existing user) 
+      - The password to set when the user is created. (Use C(force_password) if you want to change the password of an existing user)
     type: str
   force_password:
     description:
@@ -125,7 +125,7 @@ def _get_group_modifications(occ, module, chdir, name, groups, user_info):
   # add all groups that are not yet assigned to the user
   add_groups = target_groups - current_groups
   # remove all groups they are currently assigned to that are not part of the new group list
-  remove_groups = current_groups - target_groups  
+  remove_groups = current_groups - target_groups
   # create all new groups that do not exist on the system
   create_groups = add_groups - existing_groups
 
@@ -136,7 +136,7 @@ def _get_user_info(occ, module, chdir, name):
     err = ''
     out = ''
 
-    cmd = [occ] + ['user:list', '--no-warnings', '--output', 'json', "-a", "uid", "-a", "displayName", "-a", "email", "-a", "enabled", name]
+    cmd = [occ] + ['user:list', '--no-warnings', '--output', 'json', "-a", "uid", "-a", "displayName", "-a", "email", "-a", "enabled"]
     rc, out_occ, err_occ = module.run_command(cmd, cwd=chdir)
     out += out_occ
     err += err_occ
@@ -147,7 +147,7 @@ def _get_user_info(occ, module, chdir, name):
         _fail(module, cmd, out, err)
 
     module.log(msg=out_occ)
-    
+
     # nothing was returned with our search time
     if type(json_out) == list:
         return {}
@@ -164,43 +164,45 @@ def _get_user_info(occ, module, chdir, name):
 
       if rc != 0:
           _fail(module, cmd, out, err)
-      
+
       user_groups = json.loads(out_occ)
       user_info['groups'] = user_groups
 
     return user_info
 
 def _get_occ(module, executable=None):
-    candidate_occ_basenames = ('occ',)
-    occ = None
-    if executable is not None:
-        if os.path.isabs(executable):
-            occ = executable
-        else:
-            candidate_occ_basenames = (executable,)
+  occ = None
+  candidate_occ_basenames = ('occ',)
+  if executable is not None:
+      if os.path.isabs(executable):
+          occ = executable
+      else:
+          candidate_occ_basenames = (executable,)
 
-    if occ is None:
-        for basename in candidate_occ_basenames:
-            occ = module.get_bin_path(basename, False, opt_dirs=['/usr/local/bin'])
-            if occ is not None:
-                break
-        else:
-            # For-else: Means that we did not break out of the loop
-            # (therefore, that occ was not found)
-            module.fail_json(msg='Unable to find any of %s to use. occ'
-                                 ' needs to be installed.' % ', '.join(candidate_occ_basenames))
+  if occ is None:
+    for basename in candidate_occ_basenames:
+      occ = module.get_bin_path(basename, False, opt_dirs=['/usr/local/bin'])
+      if occ is not None:
+          break
+    else:
+      # For-else: Means that we did not break out of the loop
+      # (therefore, that occ was not found)
+      module.fail_json(
+          msg=
+          f"Unable to find any of {', '.join(candidate_occ_basenames)} to use. occ needs to be installed."
+      )
 
-    return occ
+  return occ
 
 
 
 def _fail(module, cmd, out, err):
-    msg = ''
-    if out:
-        msg += "stdout: %s" % (out, )
-    if err:
-        msg += "\n:stderr: %s" % (err, )
-    module.fail_json(cmd=cmd, msg=msg)
+  msg = ''
+  if out:
+    msg += f"stdout: {out}"
+  if err:
+      msg += "\n:stderr: %s" % (err, )
+  module.fail_json(cmd=cmd, msg=msg)
 
 
 def main():
@@ -264,9 +266,9 @@ def main():
 
     run_cmd = (user_exists and state == "absent") or (not user_exists and state == "present")
     run_modify_display_name = display_name is not None and state == "present" and user_exists and display_name != user_info['displayName']
-    run_modify_email = email is not None and state == "present" and user_exists and email != user_info['email']    
+    run_modify_email = email is not None and state == "present" and user_exists and email != user_info['email']
     run_dis_enable = (user_exists and enable != user_info.get('enabled', False)) or (not user_exists and not enable)
-    
+
     # set add or del command
     commands = []
     user_cmd = [occ] + state_map[state]
@@ -276,7 +278,7 @@ def main():
     group_add_cmd = [occ] + ["group:add-member"]
     group_del_cmd = [occ] + ["group:remove-member"]
     group_create_cmd = [occ] + ["group:add"]
-    
+
 
     if run_cmd:
         cmd_env = dict()
@@ -290,7 +292,7 @@ def main():
               user=name,
               msg=["Password is required to create a new user!"],
             )
-          
+
           if display_name is not None:
             cmd.append("--display-name")
             cmd.append(display_name)
@@ -314,7 +316,7 @@ def main():
             cmd = modify_cmd+["displayname", display_name]
             (out, err, out_occ, err_occ) = _run_occ_cmd(module, cmd, chdir, out, err, commands)
             changed += out_occ
-        
+
         if run_modify_email:
             cmd = modify_cmd+["email", email]
             (out, err, out_occ, err_occ) = _run_occ_cmd(module, cmd, chdir, out, err, commands)
@@ -325,7 +327,7 @@ def main():
             (out, err, out_occ, err_occ) = _run_occ_cmd(module, cmd, chdir, out, err, commands)
             changed += name+" has been "
             changed += "enabled\n" if enable else "disabled\n"
-            
+
         if user_exists:
             if force_password:
                 if password is not None:

--- a/roles/config/defaults/main.yml
+++ b/roles/config/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# defaults file for owncloud-config
-
 # user & group configuration
 owncloud_groups_group: []
 owncloud_groups_host: []

--- a/roles/config/meta/main.yml
+++ b/roles/config/meta/main.yml
@@ -2,52 +2,16 @@ galaxy_info:
   author: Maximilian Frank
   description: This role can be used to pre configure owncloud users, groups and remote file system mounts
   company: AIT Austrian Institute of Technology
+  license: GPL-3
 
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
+  min_ansible_version: 2.10.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
 
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
-
-  min_ansible_version: 2.10
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
-  galaxy_tags: 
+  galaxy_tags:
     - owncloud
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/config/tasks/main.yml
+++ b/roles/config/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for owncloud-config
-
 - name: Configure owncloud user groups
   ait.owncloud.oc_group:
     name: "{{ item.group }}"
@@ -51,10 +49,10 @@
     # oauth2 authentication backend config
     oauth2_client_id: "{{ item.oauth2_client_id | default(omit) }}"
     oauth2_client_secret: "{{ item.oauth2_client_secret | default(omit) }}"
-    # rsa private key 
+    # rsa private key
     private_key: "{{ item.private_key | default(omit) }}"
     # mount owncloud options (e.g., sharing)
-    options: "{{ ( owncloud_mount_options | combine(item.get('options', {})) ) if owncloud_mount_options is defined else item.options | default(omit) }}"
+    options: "{{ (owncloud_mount_options | combine(item.get('options', {}))) if owncloud_mount_options is defined else item.options | default(omit) }}"
     # executable configuration
     chdir: "{{ (item.chdir | default(owncloud_chdir)) | default(omit) }}"
     executable: "{{ (item.executable | default(owncloud_executable)) | default(omit) }}"

--- a/roles/config/vars/main.yml
+++ b/roles/config/vars/main.yml
@@ -1,17 +1,14 @@
 ---
-# vars file for owncloud-config
-
-# global configuration options
-owncloud_users_force_password: False
+owncloud_users_force_password: false
 # owncloud_chdir: <some directory>
 # owncloud_executable: occ
 
-# user & group configuration 
+# user & group configuration
 # (membership is controlled as part of the user configuration)
 owncloud_groups: "{{ owncloud_groups_group + owncloud_groups_host }}"
 owncloud_users: "{{ owncloud_users_group + owncloud_users_host }}"
 
 # remote filesystem mounts
 owncloud_mounts: "{{ owncloud_mounts_group + owncloud_mounts_host }}"
-# global owncloud mount options can be configured like this 
+# global owncloud mount options can be configured like this
 # owncloud_mount_options: { read_only: True }


### PR DESCRIPTION
Fixes bug where users with a '_' character in their name would fail due to a bug in `occ user:list`

The users won't be shown if queried by name from `occ user:list` like `occ user:list first_last` but will be in the output if grepped from the unfiltered list.
`occ user:list  | grep first_last`

